### PR TITLE
fix issue when render is incomplete on height grow

### DIFF
--- a/pl-virtual-scroll.js
+++ b/pl-virtual-scroll.js
@@ -252,6 +252,9 @@ class PlVirtualScroll extends PlElement {
 
             if (Math.abs(predictedHeight - currentHeight) > restRows / 10 * avgHeight) {
                 canvas.style.setProperty('height', predictedHeight + 'px');
+                if (predictedHeight - currentHeight > avgHeight) {
+                    setTimeout(() => this.render(), 0);
+                }
             }
         }
 


### PR DESCRIPTION
Resolved an issue where the list would not fully render when the container's height dynamically expanded based on content. After the initial render, the canvas height was recalculated. However, if the container size increased significantly, a re-render was not triggered, leaving the newly allocated space unrendered. This fix ensures that the canvas properly re-renders to accommodate height changes.